### PR TITLE
Iterate over Pod list to conserve memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # Dependency directories (remove the comment below to include it)
 # vendor/
+
+pod-janitor

--- a/cmd/pod-janitor.go
+++ b/cmd/pod-janitor.go
@@ -24,8 +24,5 @@ func main() {
 		log.Fatalf("Failed to initialise Cleaner: %v", err)
 	}
 
-	err = cleanerArgs.RunCleaner()
-	if err != nil {
-		log.Fatalf("Failed to run Cleaner: %v", err)
-	}
+	cleanerArgs.RunCleaner()
 }


### PR DESCRIPTION
This limits the retrieving of `Pods` to clean to 10 at a time, iterating over the stable snapshot until no more results are available.
This should limit the amount of memory allocated to a near-constant value during each run as GC should free up space held by Pods that have finished processing.